### PR TITLE
Allow slashes in job name

### DIFF
--- a/jenkins_badges/coverage_badge/__init__.py
+++ b/jenkins_badges/coverage_badge/__init__.py
@@ -10,7 +10,7 @@ Coverage = namedtuple("Coverage", ["formatted", "colour"])
 coverage_badge = Blueprint('coverage_badge', __name__)
 
 
-@coverage_badge.route("/coverage/<job_name>", methods=['GET'])
+@coverage_badge.route("/coverage/<path:job_name>", methods=['GET'])
 def send_coverage_badge(job_name):
     if job_name == "favicon.ico":
         return "", 200


### PR DESCRIPTION
Some Jenkins instances are configured to name jobs with a path-like syntax (e.g. 'dsyed/job/example/job/master'). By default, Flask will treat a job name like that as a different path on the server. Telling Flask to expect a 'path' allows access to the entire job name as a string.